### PR TITLE
Gallery entry for the circle packing layout

### DIFF
--- a/web/gallery/CirclePacking.lhs
+++ b/web/gallery/CirclePacking.lhs
@@ -1,0 +1,42 @@
+---
+title: Circle Packing
+author: Joachim Breitner
+authorurl: http://www.joachim-breitner.de/
+date: 2012-12-16
+description: Automatically arranging diagrams in a compact circular fashion
+tags: layout
+width: 400
+view: -10,-10,10,10
+---
+
+> {-# LANGUAGE NoMonomorphismRestriction #-}
+> 
+> import Diagrams.Prelude
+
+This code demonstrates the circle-packing layout from the `diagrams-contrib`
+package. For more information on the algorithm used, see the `circle-packing`
+package.
+
+> import Diagrams.TwoD.Layout.CirclePacking
+
+Lets collect some objects of varying size and color to draw. They do not need
+to be single shapes but can be arbitrary complex diagrams, as demonstrated by
+including some Spierpinsky triangles among them.
+
+> colorize = zipWith fc $
+>    cycle [red,blue,yellow,magenta,cyan,bisque,firebrick,indigo]
+> 
+> sierpinski 1 = eqTriangle 1
+> sierpinski n = (s === (s ||| s) # centerX) # alignY (-1/3)
+>   where s = sierpinski (n-1)
+
+> objects = map (lw 0.03) $ colorize $
+>     scale 0.04 (sierpinski 7) :
+>     scale 0.03 (sierpinski 7) :
+>     [ circle r  | r <- [0.1,0.2..1.6] ] ++
+>     [ hexagon r | r <- [0.1,0.2..0.7] ] ++
+>     [ decagon r | r <- [0.1,0.2..0.7] ]
+
+And now we can leave the layouting to `diagrams-contrib`:
+
+> example = pad 1.1 $ renderCirclePacking (approxRadius 6) objects


### PR DESCRIPTION
As promised, an entry for the gallery using the new CirclePacking layout.

I did not manage to the the whole of diagrams-doc to build, but I tested the code using `~/.cabal/bin/diagrams-builder-svg`, I hope that is sufficient.

I added the Sierpinsky triangle as an example for a more complex figure, although it spoils the visual impression a bit, so I’m not settled on them.
