### PR TITLE
Update for new Angle type, @@ operator

### DIFF
--- a/doc/arrow.rst
+++ b/doc/arrow.rst
@@ -54,8 +54,8 @@ options used to make arrows.
 >             # scale 0.75
 >   where
 >     c = circle 1 # showOrigin # lw 0.04
->     a = arc (5/12 :: Turn) (11/12 :: Turn)
->     a1 = arc (1/2 :: Turn) (3/4 :: Turn)
+>     a = arc (5/12 @@ turn) (11/12 @@ turn)
+>     a1 = arc (1/2 @@ turn) (3/4 @@ turn)
 >     t = bezier3 (r2 (1,1)) (r2 (1,1)) (r2 (0,2))
 >     t' = reflectX t
 >     l = straight unitX
@@ -83,7 +83,7 @@ Optional and named parameters
 Most of the arrow functions take an `opts` parameter (see `Faking
 optional named parameters`__) of type `ArrowOpts`, these functions typically
 have companion functions that use a default set of `ArrowOpts`. For example
-the functions `arrow'` and `arrow`. The former takes and `opts` parameter and
+the functions `arrow'` and `arrow`. The former takes an `opts` parameter and
 the latter does not. In this tutorial whenever we mention a function with
 a single quote (`'`) at the end, there is a sister function without the quote that
 uses a default set of options.
@@ -247,7 +247,7 @@ will make the arrow shaft into an arc:
 
 ::
 
-> shaft = arc 0 (1/2 :: Turn)
+> shaft = arc 0 (1/2 @@ turn)
 >
 > example = ( sDot <> eDot
 >          <> arrowBetween' (with & arrowHead .~ spike & arrowTail .~ spike'
@@ -265,7 +265,7 @@ will make the arrow shaft into an arc:
 > sDot = dot # fc blue # moveTo sPt
 > eDot = dot # fc red # moveTo ePt
 >
-> shaft = arc 0 (1/2 :: Turn)
+> shaft = arc 0 (1/2 @@ turn)
 >
 > example = ( sDot <> eDot
 >          <> arrowBetween' (with & arrowHead .~ spike & arrowTail .~ spike'
@@ -286,7 +286,7 @@ vertically.
 
 In order to get the arrow to curve upwards we might initially think we
 could create the shaft reversing the order of the angles, using `arc
-(1/2 :: Turn) 0`, but this won't work either, as it creates a
+(1/2 @@ turn) 0`, but this won't work either, as it creates a
 downwards curving arc from, say, `(0,0)`:math: to `(1,0)`:math: that
 does not need to be rotated. The only way to achieve the desired
 result of making the arrow pointing from `(0,0)`:math: to
@@ -296,7 +296,7 @@ result of making the arrow pointing from `(0,0)`:math: to
 
 ::
 
-> shaft = arc 0 (1/2 :: Turn) # reverseTrail
+> shaft = arc 0 (1/2 @@ turn) # reverseTrail
 
 .. class:: dia
 
@@ -307,7 +307,7 @@ result of making the arrow pointing from `(0,0)`:math: to
 > dot = circle 0.02 # lw 0
 > sDot = dot # fc blue # moveTo sPt
 > eDot = dot # fc red # moveTo ePt
-> shaft = arc 0 (1/2 :: Turn) # reverseTrail
+> shaft = arc 0 (1/2 @@ turn) # reverseTrail
 > example = ( sDot <> eDot
 >          <> arrowBetween' (with & arrowHead .~ spike & arrowTail .~ spike'
 >                                 & arrowShaft .~ shaft) sPt ePt)
@@ -517,8 +517,8 @@ diagram.
 
 ::
 
-> connectPerim "diagram1" "diagram2" (5/12 :: Turn) (1/12 :: Turn)
-> connectPerim "diagram" "diagram" (2/12 :: Turn) (4/12 :: Turn)
+> connectPerim "diagram1" "diagram2" (5/12 @@ turn) (1/12 @@ turn)
+> connectPerim "diagram" "diagram" (2/12 @@ turn) (4/12 @@ turn)
 
 Here is an example of a finite state automata that accepts real numbers.
 The code is a bit longer than what we have seen so far, but still very
@@ -553,8 +553,8 @@ straightforward.
 >
 > states = position (zip points ds)
 >
-> shaft = arc 0 (1/6 :: Turn)
-> shaft' = arc 0 (1/2 :: Turn) # scaleX 0.33
+> shaft = arc 0 (1/6 @@ turn)
+> shaft' = arc 0 (1/2 @@ turn) # scaleX 0.33
 > line = trailFromOffsets [unitX]
 >
 > arrowStyle1 = (with  & arrowHead  .~ noHead & tailSize .~ 0.3
@@ -570,26 +570,26 @@ straightforward.
 >                       & tailColor  .~ black)
 >
 > example = states # connectPerim' arrowStyle1
->                                  "2" "1" (5/12 :: Turn) (1/12 :: Turn)
+>                                  "2" "1" (5/12 @@ turn) (1/12 @@ turn)
 >                  # connectPerim' arrowStyle3
->                                  "4" "1" (2/6 :: Turn) (5/6 :: Turn)
+>                                  "4" "1" (2/6 @@ turn) (5/6 @@ turn)
 >                  # connectPerim' arrowStyle2
->                                  "2" "2" (2/12 :: Turn) (4/12 :: Turn)
+>                                  "2" "2" (2/12 @@ turn) (4/12 @@ turn)
 >                  # connectPerim' arrowStyle1
->                                  "3" "2" (5/12 :: Turn) (1/12 :: Turn)
+>                                  "3" "2" (5/12 @@ turn) (1/12 @@ turn)
 >                  # connectPerim' arrowStyle2
->                                  "3" "3" (2/12 :: Turn) (4/12 :: Turn)
+>                                  "3" "3" (2/12 @@ turn) (4/12 @@ turn)
 >                  # connectPerim' arrowStyle1
->                                  "5" "4" (5/12 :: Turn) (1/12 :: Turn)
+>                                  "5" "4" (5/12 @@ turn) (1/12 @@ turn)
 >                  # connectPerim' arrowStyle2
->                                  "5" "5" (-1/12 :: Turn) (1/12 :: Turn)
+>                                  "5" "5" (-1/12 @@ turn) (1/12 @@ turn)
 
 In the following exercise you can try `connectPerim'` for yourself.
 
 .. container:: exercises
 
   Create a torus (donut) with `16`:math: curved arrows pointing from the
-  outer ring to the inner ring at the same angle every `(1/16) :: Turn`.
+  outer ring to the inner ring at the same angle every `1/16 @@ turn`.
 
     .. class:: dia
 
@@ -606,17 +606,17 @@ In the following exercise you can try `connectPerim'` for yourself.
     >
     > d = bullseye <> target
     >
-    > shaft = arc 0 (1/6 :: Turn)
+    > shaft = arc 0 (1/6 @@ turn)
     >
-    > connectTarget :: (Angle a, Renderable (Path R2) b)
-    >               =>  a -> (Diagram b R2 -> Diagram b R2)
+    > connectTarget :: (Renderable (Path R2) b)
+    >               =>  Angle -> (Diagram b R2 -> Diagram b R2)
     > connectTarget a = connectPerim' (with & arrowHead .~ thorn & shaftStyle %~  lw 0.01
     >                                       & arrowShaft .~ shaft & headSize .~ 0.18
     >                                       & arrowTail .~ thorn'
     >                                      ) "target" "bullseye" a a
     >
-    > angles :: [Turn]
-    > angles = [0, 1/16 .. 15/16]
+    > angles :: [Angle]
+    > angles = map (@@ turn) [0, 1/16 .. 15/16]
     >
     > example = foldr connectTarget d angles
 

--- a/doc/cmdline.rst
+++ b/doc/cmdline.rst
@@ -704,7 +704,7 @@ know what time it is.  Consider the following program.
 >
 >     bigHand    = (0 ^& (-1.5)) ~~ (0 ^& 7.5) # lw 0.5
 >     littleHand = (0 ^& (-2))   ~~ (0 ^& 9.5) # lw 0.2
->     f n v = rotate (Turn (- v / n))
+>     f n v = rotate (- v / n @@ turn)
 > 
 > main = mainWith (clock <$> getCurrentTime)
 
@@ -730,7 +730,7 @@ Running we get:
 >
 >     bigHand    = (0 ^& (-1.5)) ~~ (0 ^& 7.5) # lw 0.5
 >     littleHand = (0 ^& (-2))   ~~ (0 ^& 9.5) # lw 0.2
->     f n v = rotate (Turn (- v / n))
+>     f n v = rotate (- v / n @@ turn)
 >
 > example = clock $ read "2013-11-19 03:14:15.926535 UTC" 
 

--- a/doc/icons/Warning.hs
+++ b/doc/icons/Warning.hs
@@ -10,7 +10,7 @@ import           Diagrams.Backend.Cairo.CmdLine
 #endif
 import           Diagrams.Prelude
 
-signSide = hrule 1 <> arc (-1/4 :: CircleFrac) ((-1/4) + 1/3) # scale 0.3
+signSide = hrule 1 <> arc (-1/4 @@ turn) ((-1/4) + 1/3) # scale 0.3
 
 sign = mconcat . take 3 . iterate (rotateBy (1/3)) $ signSide
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -706,36 +706,30 @@ two-dimensional space:
 Angles
 ~~~~~~
 
-The `Angle` type class classifies types which measure two-dimensional
-angles.  Three instances are provided by default (you can, of course,
-also make your own):
+The `Angle` type represents two-dimensional angles.  Angles can be
+expressed in radians, degrees, or fractions of a circle.
 
-* `Turn` represents fractions of a circle.  A value of `1`
-  represents a full turn, `1/4 :: Turn` represents a right angle, and
-  so on.
-* `Rad` represents angles measured in radians.  A value of `tau` (that
+* `turn` represents fractions of a circle.  A value of `1` represents
+  a full turn, `1/4 @@ turn` constructs a right angle, and so on.  The
+  measure of an Angle ``a`` in turns (of type `Double`), can be gotten
+  by `a ^. turn`.
+* `rad` represents angles measured in radians.  A value of `tau` (that
   is, `\tau = 2 \pi`:math:) represents a full turn. (If you haven't heard of
   `\tau`:math:, see `The Tau Manifesto`__.)
-* `Deg` represents angles measured in degrees.  A value of `360`
+* `deg` represents angles measured in degrees.  A value of `360`
   represents a full turn.
+
+`turn`, `rad`, and `deg` are isomorphisms, represented using the `Iso`
+type from `lens`:pkg:.  The operators `^.` and `@@` can be used with
+any `Iso`.  Unfortunately, all of these have rather cryptic type
+signatures, and error messages can be hard to understand
 
 __ http://tauday.com
 
-The intention is that to pass an argument to a function that expects a
-value of some `Angle` type, you can write something like `(3 :: Deg)`
-or `(3 :: Rad)`.  The `convertAngle` function is also provided for
-converting between different angle representations.
-
-The functions `asTurn`, `asRad`, and `asDeg` are provided for
-convenience. They are all the identity function, but with restricted
-types (for example, `asTurn :: Turn -> Turn`).  Occasionally this can
-be useful to help resolve ambiguity.  For example, `rotation . asTurn
-. fromRational` is a function of type `Rational -> T2` which converts
-a rational number `r`:math: into a rotation of `r`:math: turns.  The
-expression becomes ambiguous if the call to `asTurn` is omitted, since
-`fromRational` can output any instance of `Fractional`, and `rotation`
-accepts any instance of `Angle`.  Inserting `asTurn` fixes the
-intermediate type and resolves the ambiguity.
+The intention is that to pass an argument to a function that expects
+an `Angle`, you can write something like `(3 @@ deg)` or `(3 @@ rad)`.
+The function can use whatever units internally, and this should be
+transparent to the user.
 
 The `direction` function computes the angle of a vector, measured
 clockwise from the positive `x`:math:\-axis.
@@ -797,8 +791,8 @@ __ `Angles`_
 
 > example = hcat [arc a1 a2, strutX 1, wedge 1 a1 a2]
 >   where
->     a1 = tau/4 :: Rad
->     a2 = 4 * tau / 7 :: Rad
+>     a1 = tau/4 @@ rad
+>     a2 = 4 * tau / 7 @@ rad
 
 Pre-defined shapes
 ~~~~~~~~~~~~~~~~~~
@@ -873,7 +867,7 @@ optional parameters that control the generated polygon:
 
       > example = polygon ( with
       >   & polyType .~ PolySides
-      >       [ 20 :: Deg, 90 :: Deg, 40 :: Deg, 100 :: Deg ]
+      >       [ 20 @@ deg, 90 @@ deg, 40 @@ deg, 100 @@ deg ]
       >       [ 1        , 5        , 2        , 4          ]
       >   )
 
@@ -897,7 +891,7 @@ optional parameters that control the generated polygon:
 
 > poly1 = polygon ( with & polyType  .~ PolyRegular 13 5
 >                        & polyOrient .~ OrientV )
-> poly2 = polygon ( with & polyType  .~ PolyPolar (repeat (1/40 :: Turn))
+> poly2 = polygon ( with & polyType  .~ PolyPolar (repeat (1/40 @@ turn))
 >                                                 (take 40 $ cycle [2,7,4,6]) )
 > example = (poly1 ||| strutX 1 ||| poly2) # lw 0.05
 
@@ -1483,11 +1477,12 @@ Rotation
 
 Use `rotate` to rotate a diagram counterclockwise by a given angle__
 about the origin.  Since `rotate` takes an angle, you must specify an
-angle type, such as `rotate (80 :: Deg)`.  In the common case that you
+angle type, such as `rotate (80 @@ deg)`.  In the common case that you
 wish to rotate by an angle specified as a certain fraction of a
-circle, like `rotate (1/8 :: Turn)`, you can use `rotateBy`
-instead. `rotateBy` is specialized to only accept `Turn`\s, so in this
-example you would only have to write `rotateBy (1/8)`.
+circle, like `rotate (1/8 @@ turn)`, you can use `rotateBy`
+instead. `rotateBy` takes a `Double` argument expressing the number of
+turns, so in this example you would only have to write `rotateBy
+(1/8)`.
 
 You can also use `rotateAbout` in the case that you want to rotate
 about some point other than the origin.
@@ -1570,7 +1565,7 @@ thus:
 ::
 
 > eff = text "F" <> square 1 # lw 0
-> example = (scaleX 2 `under` rotation (-1/8 :: Turn)) eff
+> example = (scaleX 2 `under` rotation (-1/8 @@ turn)) eff
 
 The letter F is first rotated so that the desired scaling axis lies
 along the `x`:math:\-axis; then `scaleX` is performed; then it is rotated back
@@ -1670,15 +1665,15 @@ polygon):
 >                   [ 0.25,1,1,1,1] & polyOrient .~ NoOrient )
 >                   # fc blue # lw 0
 >   where
->     a = 1/8 :: Turn
->     b = 1/4 :: Turn
+>     a = 1/8 @@ turn
+>     b = 1/4 @@ turn
 >
 > convex = polygon (with & polyType .~ PolyPolar [a,b] [0.25, 1, 1]
 >                        & polyOrient .~ NoOrient)
 >                        # fc orange # lw 0
 >   where
->     a = 1/8 :: Turn
->     b = 3/4 :: Turn
+>     a = 1/8 @@ turn
+>     b = 3/4 @@ turn
 >
 > aligned = (concave # centerXY # alignR # showOrigin)
 >        <> (convex # centerXY # alignL # showOrigin)
@@ -2819,7 +2814,7 @@ __ /gallery/SymmetryCube.html
 >
 > -- Connect two diagrams and two points on their trails.
 > ex23 = ds # connect "1" "2"
->           # connectPerim "1" "2" (15/16 :: Turn) (9/16 :: Turn)
+>           # connectPerim "1" "2" (15/16 @@ turn) (9/16 @@ turn)
 >
 > -- Place an arrow at (0,0) the size and direction of (0,1).
 > ex4 = arrowAt (0 ^& 0) unit_Y
@@ -2890,7 +2885,7 @@ function.
 >
 > shaft1 = trailFromVertices (map p2 [(0, 0), (1, 0), (1, 0.2), (2, 0.2)])
 > shaft2 = cubicSpline False (map p2 [(0, 0), (1, 0), (1, 0.2), (2, 0.2)])
-> shaft3 = arc 0 (1/6 :: Turn)
+> shaft3 = arc 0 (1/6 @@ turn)
 >
 > example = d
 >    # connect' (with & arrowTail .~ quill& tailSize .~ 1.5
@@ -3866,7 +3861,7 @@ The arrows on the right are wrapped in `ScaleInv` but the ones on the left are n
 >             (map (centerX . showT)
 >               [ scalingX (1/2)
 >               , scalingY 2
->               , scalingX (1/2) <> rotation (-1/12 :: Turn)
+>               , scalingX (1/2) <> rotation (-1/12 @@ turn)
 >               ])
 
 In addition, the `scaleInvPrim` function creates a scale-invariant

--- a/doc/paths.rst
+++ b/doc/paths.rst
@@ -255,15 +255,14 @@ some lines and then call `glueLine` on the result.  You try:
 
      > andThen t1 t2 = t1 <> t2 # rotate (d1 - d2)
      >   where
-     >     d1, d2 :: Rad
      >     d1 = direction (tangentAtEnd t1)
      >     d2 = direction (tangentAtStart t2)
      >
      > str = fromOffsets [unitX]
-     > cap = arc 0 (1/2 :: Turn)
+     > cap = arc 0 (1/2 @@ turn)
      > arm = str `andThen` cap `andThen` str
      >
-     > armUnit = arm `andThen` (arc 0 (3/10 :: Turn) # reflectX)
+     > armUnit = arm `andThen` (arc 0 (3/10 @@ turn) # reflectX)
      >
      > example = foldr andThen mempty (replicate 5 armUnit)
      >   # glueLine # strokeLoop # fc blue
@@ -278,7 +277,6 @@ some lines and then call `glueLine` on the result.  You try:
 
      > andThen t1 t2 = t1 <> t2 # rotate (d1 - d2)
      >   where
-     >     d1, d2 :: Rad
      >     d1 = direction (tangentAtEnd t1)
      >     d2 = direction (tangentAtStart t2)
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -420,7 +420,7 @@ for transforming diagrams, such as:
 
 * `scale` (scale uniformly)
 * `scaleX` and `scaleY` (scale in the X or Y axis only)
-* `rotate` (rotate by an angle in radians)
+* `rotate` (rotate by an Angle)
 * `rotateBy` (rotate by a fraction of a circle)
 * `reflectX` and `reflectY` for reflecting along the X and Y axes
 

--- a/doc/vector.rst
+++ b/doc/vector.rst
@@ -167,7 +167,7 @@ The first thing to learn is how to *create* values of type
   ::
 
   > example = lw 0.05 . mconcat . map fromOffsets
-  >         $ [ [r *^ fromDirection (Rad r)]
+  >         $ [ [r *^ fromDirection (r @@ rad)]
   >           | r <- [33 * tau/32, 34 * tau/32 .. 2 * tau]
   >           ]
 
@@ -189,7 +189,7 @@ The first thing to learn is how to *create* values of type
 
      ::
 
-     > vs = [ 5 *^ fromDirection (r :: Turn) | r <- [-1/4, -1/4 + 1/12 .. 1/4] ]
+     > vs = [ 5 *^ fromDirection (r @@ turn) | r <- [-1/4, -1/4 + 1/12 .. 1/4] ]
      > example = mconcat (map (\v -> unitCircle # translate v) vs)
      >         # fc blue
      >         # centerXY
@@ -200,7 +200,7 @@ The first thing to learn is how to *create* values of type
 
      ::
 
-     > vs = zipWith mkV (cycle [1,2,3]) [ 1/30, 2/30 .. 1 :: Turn ]
+     > vs = zipWith mkV (cycle [1,2,3]) [ 1/30, 2/30 .. 1 @@ turn ]
      >   where mkV r th = r *^ fromDirection th
      > example = lw 0.02 . mconcat . map (fromOffsets . (:[])) $ vs
 

--- a/logo/Logo.hs
+++ b/logo/Logo.hs
@@ -25,8 +25,8 @@ ico_d = (stroke $
         # lw 0
 
 {-
-dAngle :: Rad
-dAngle = tau / 6
+dAngle :: Angle
+dAngle = tau / 6 @@ rad
 
 dHeight = 5
 dWidth  = 1
@@ -35,7 +35,7 @@ dRad = 1.5
 
 dPath = pathFromTrail . close $
         arc dAngle (tau - dAngle) # scale dRad
-     <> fromOffsets [ (0, -(1 - cos (tau/4 - getRad dAngle)) * dRad)
+     <> fromOffsets [ (0, -(1 - cos (tau/4 - (dAngle ^. rad))) * dRad)
                     , (dWidth, 0)
                     , (0, dHeight)
                     , (-dWidth, 0)
@@ -120,7 +120,7 @@ r = sketchTurtle (setHeading 90 >> forward 5 >> right 90
   # lc orange
   # (withName "end" $ atop . place turtle . location)
   where
-    turtle = eqTriangle 1 # scaleY 1.3 # rotate (-135 :: Deg)
+    turtle = eqTriangle 1 # scaleY 1.3 # rotate (-135 @@ deg)
              # lw 0.1
 
 aTree = BNode () f f


### PR DESCRIPTION
I think this has all necessary changes to the manual.  I grepped for occurrences of 'turn', 'rad', 'deg', and 'angle', and fixed each.

However, the Haddock links from the manual are broken.  Links for `Angle` and related functions point to `Diagrams.ThreeD`, where I export them, rather than to `Diagrams.TwoD.Types` where they are defined.  Is there a sensible way to make the links go the right place, or should I stop reexporting them for now? 
