### PR TITLE
Add section on Deform to manual

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1454,7 +1454,7 @@ vector function of the form `f(\mathbf{v}) = \mathbf{M}\mathbf{v} +
 \mathbf{B}`:math:, where `\mathbf{M}`:math: and `\mathbf{B}`:math: are
 `d \times d`:math: matrices.  More general, non-affine
 transformations, including projective transformations, are referred to
-in ``diagrams`` as `Deformations`_
+in ``diagrams`` as `Deformations`_.
 
 `Diagrams.TwoD.Transform`:mod: defines a number of common affine
 transformations in two-dimensional space. (To construct


### PR DESCRIPTION
Here's some documentation to accompany https://github.com/diagrams/diagrams-lib/pull/148  It at least explains the aspects of what's `Deformable` that gave me headaches writing the code.

Is there a way to mark up `Transformation`s that will be linked correctly?  Sometimes the plural is correct in the sentence, but when I place backticks in the obvious place, the .rst parsing shows them in the output HTML, and there's no link.
