### PR TITLE
Fixed the link to api reference in the manual.

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -118,7 +118,7 @@ about ``diagrams``:
   for a list of open tickets.  If you find a bug or would like to
   request a feature, please file a ticket!
 
-.. _`from the diagrams website`: http://projects.haskell.org/diagrams/doc/index.html
+.. _`from the diagrams website`: http://projects.haskell.org/diagrams/reference.html
 .. _`report it as a bug`: https://github.com/diagrams/diagrams-doc/issues
 .. _website: http://projects.haskell.org/diagrams
 .. _`list of tutorials`: http://projects.haskell.org/diagrams/documentation.html


### PR DESCRIPTION
The problem is well described in issue #61

> http://projects.haskell.org/diagrams/doc/manual.html#other-resources
> says "The API reference documentation for all the diagrams packages is
> intended to be high-quality and up-to-date, and is available from the
> diagrams website.". It links to
> http://projects.haskell.org/diagrams/doc/index.html, but the latter
> does not exist.
