### PR TITLE
Search field that sends to hoogle

### DIFF
--- a/web/js/hoogle-search.js
+++ b/web/js/hoogle-search.js
@@ -1,0 +1,11 @@
+var PACKAGES = '+diagrams-contrib +diagrams-lib +diagrams-core +diagrams-canvas \
++diagrams-cairo +diagrams-rasterific +diagrams-svg +diagrams-builder \
++diagrams-postscript +active +palette +diagrams-constraints'
+
+$(document).ready(function(){
+    $('#search').submit(function(event){
+        window.location.href = 'http://haskell.org/hoogle?hoogle='
+                             + encodeURIComponent($('#hoogle').val() + ' ' + PACKAGES);
+        event.preventDefault();
+    });
+});

--- a/web/templates/default.html
+++ b/web/templates/default.html
@@ -65,6 +65,13 @@
               </ul>
 	    </li>
             <li><a href="/blog/index.html">Blog</a></li>
+	    <li>
+	        <form id="search" class="navbar-form navbar-left" role="search" method="get" action="http://haskell.org/hoogle">
+	            <div class="form-group">
+	                <input id="hoogle" name="hoogle" type="text" class="form-control" placeholder="API Search">
+	            </div>
+	        </form>
+	    </li>
 	   </ul>
         </div>
       </div>
@@ -79,5 +86,6 @@
     <script src="https://code.jquery.com/jquery.js"></script>
     <script src="/js/bootstrap.min.js"></script>
     <script src="/js/bootstrap-docs-application.js"></script>
+    <script src="/js/hoogle-search.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The list of diagrams' packages gets appended to the query.

issue #23

List of appended packages can be modified by changing variable
`PACKAGES` in `web/js/hoogle-search.js`. At the moment it is"

```
var PACKAGES = '+diagrams-contrib +diagrams-lib +diagrams-core +diagrams-canvas \
+diagrams-cairo +diagrams-rasterific +diagrams-svg +diagrams-builder \
+diagrams-postscript +active +palette +diagrams-constraints'
```
