### PR TITLE
Specify GHC version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 
 before_script:
   # Set up stack globally (download ghc)
-  - stack setup
+  - stack setup 7.10.3
 
   - ./generate-stack-yaml.hs
 


### PR DESCRIPTION
[Diagrams builds](https://travis-ci.org/diagrams/diagrams-doc/builds/308228972#L563) are failing because `stack setup` installs ghc-8.0.2 (lts-9.14), but `./generate-stack-yaml.hs` requires ghc-7.10.3 (lts-6.22). `generate-stack-yaml.hs` is a script, so it can't force `stack setup` to install it's ghc.

This should make travis' builds stop failing