### PR TITLE
Update mathjax url. mathjax.org no longer a cdn

### DIFF
--- a/web/templates/default.html
+++ b/web/templates/default.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" type="text/css" href="/css/syntax.css" />
     <link rel="shortcut icon" href="/diagrams.ico" />
 
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="https://cdn.rawgit.com/mathjax/MathJax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     $bannerCSS$
   </head>
   <body>


### PR DESCRIPTION
Going to the [manual](https://archives.haskell.org/projects.haskell.org/diagrams/doc/manual.html) in firefox doesn't render mathjax formulas, but gives fun errors like:


![mathjax](https://user-images.githubusercontent.com/12851254/33339200-6bb50b8e-d446-11e7-92b9-94a4b658a5db.png)

https://www.mathjax.org/cdn-shutting-down/ recommends using a different cdn like rawgit. 