### PR TITLE
Testing how to stop Travis builds from failing 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   # It has caused me out-of-memory errors on Travis several times.
   - stack --no-terminal --fast build -j 1 haskell-src-exts
 
-  - stack --no-terminal --fast build
+  - stack --no-terminal --fast build -j 1
 
 script: stack exec diagrams-doc -- buildh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ before_script:
 
   # Prebuild this dependency separately because building it takes a lot of memory.
   # It has caused me out-of-memory errors on Travis several times.
-  - stack --no-terminal build --fast -j 1 haskell-src-exts
+  - stack --no-terminal build --fast -j 2 haskell-src-exts
 
-  - stack --no-terminal build --fast -j 1
+  - stack --no-terminal build --fast -j 2
 
 script: stack exec diagrams-doc -- buildh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ before_script:
 
   # Prebuild this dependency separately because building it takes a lot of memory.
   # It has caused me out-of-memory errors on Travis several times.
-  - stack --no-terminal build -j 1 haskell-src-exts
+  - stack --no-terminal --fast build -j 1 haskell-src-exts
 
-  - stack --no-terminal build
+  - stack --no-terminal --fast build
 
 script: stack exec diagrams-doc -- buildh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ before_script:
 
   # Prebuild this dependency separately because building it takes a lot of memory.
   # It has caused me out-of-memory errors on Travis several times.
-  - stack --no-terminal --fast build -j 1 haskell-src-exts
+  - stack --no-terminal build --fast -j 1 haskell-src-exts
 
-  - stack --no-terminal --fast build -j 1
+  - stack --no-terminal build --fast -j 1
 
 script: stack exec diagrams-doc -- buildh
 

--- a/blog/2017-01-03-diagrams-1.4.rst
+++ b/blog/2017-01-03-diagrams-1.4.rst
@@ -154,7 +154,7 @@ Cubic B-splines
 
 `Diagrams.CubicSpline`:mod: has a new function, `bspline`, which
 creates a smooth curve (to be precise, a [uniform cubic
-B-spline](https://en.wikipedia.org/wiki/B-spline)) with the given
+B-spline](https://en.wikipedia.org/wiki/B-spline) ) with the given
 points as control points. The curve begins and ends at the first and
 last points, and is tangent to the lines to the second-to-last control
 points.  It does not, in general, pass through the intermediate

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -623,7 +623,7 @@ traces...).
 A worked example
 ================
 
-As a way of exhibing a complete example and introducing some
+As a way of exhibiting a complete example and introducing some
 additional features of diagrams, consider trying to draw the following
 picture:
 


### PR DESCRIPTION
Travis logs [suggest](https://travis-ci.org/diagrams/diagrams-doc/builds/143609805#L796) they're failing because the process runs out of memory. Build failure in the doc repo isn't as informative as code, but if the builds are there they might as well pass.

I'll leave this open if the build still fails so I can try other ideas when I get them without opening more pull requests.